### PR TITLE
Use test message with uppercase characters

### DIFF
--- a/src/caesaroneliner.py
+++ b/src/caesaroneliner.py
@@ -25,7 +25,7 @@ def encode_cmp(message, subst):
             cipher += letter
     return cipher
 
-test_message = "test_message"
+test_message = "TEST_MESSAGE"
 subst, unsubst = create_shift_substitutions(10)
 if encode_cmp(test_message, subst) == encode(test_message, subst):
     print("[PASS]")


### PR DESCRIPTION
Only uppercase characters are encoded so the test message should not be entirely in lower case.