### PR TITLE
Updated ciphertext to the public_key encrypted data of the keys conca…

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -25,3 +25,6 @@ On **page 201** [Typo]
 The sentence "It is the subject's private key that is being stored in the certificate" should read, "It is the subject's public key that is being stored in the certificate."
 
 ****
+On **page 215** [typo]
+
+The source code at approximately line 42 reads, `ciphertext = data+signature`. It should read `ciphertext += signature`. The corresponding source code in github has also been updated.

--- a/src/rsa_exchange.py
+++ b/src/rsa_exchange.py
@@ -39,7 +39,8 @@ class TransmissionManager:
                 mgf=padding.MGF1(algorithm=hashes.SHA256()),
                 algorithm=hashes.SHA256(),
                 label=None)) # rarely used. Just leave it 'None'
-        ciphertext = data+signature
+
+        ciphertext += signature
         self.mac.update(ciphertext)
         return ciphertext
 


### PR DESCRIPTION
CH 6 pg 214 states the following:
```
The agreed-upon transmission protocol is to transmit a single stream of bytes with all
data concatenated together. The transmission stream includes
• An AES encryption key, IV, and a MAC key encrypted under Bob’s public key
• Alice’s signature over the hash of the AES key, IV, and MAC key
• The stolen document bytes, encrypted under the encryption key
• An HMAC over the entire transmission under the MAC key
```

Therefore the result from the `initialize()` function should be returning the public key encrypted data of the (AES key || iv || MAC key) concatenated with the `signature`, but I believe the return is the *unencrypted* data of (AES key || iv || MAC key) concatenated with the signature.